### PR TITLE
Fix TemplateProcessor :: fixBrokenMacros;

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -445,7 +445,7 @@ class TemplateProcessor
         $fixedDocumentPart = $documentPart;
 
         $fixedDocumentPart = preg_replace_callback(
-            '|\$[^{]*\{[^}]*\}|U',
+            '/\$(?:\{|[^{$]*\>\{)[^}$]*\}/U',
             function ($match) {
                 return strip_tags($match[0]);
             },


### PR DESCRIPTION
### Description

The current regex causes the loss of the original formatting of some documents after the variables have been overwritten.
Replaces the current regex with one that resolves this problem.
New regex from @brainwood
`/\$(?:\{|[^{$]*\>\{)[^}$]*\}/U`

The brainwood's pull request was rejected due to pipe regex delimiters "|"

Fixes #1345

Example:

We have the text
`$15000. ${variable_name}`

That breaks down to the following xml:

`<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>$</w:t></w:r><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>{</w:t></w:r><w:proofErr w:type="spellStart"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>variable_name</w:t></w:r><w:proofErr w:type="spellEnd"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>}</w:t></w:r>`

The current regex and yours would pars the `$15000. ${variable_name}` as the variable where it should just be `${variable_name}`